### PR TITLE
Update Invidious URL

### DIFF
--- a/InvidiousProvider/build.gradle.kts
+++ b/InvidiousProvider/build.gradle.kts
@@ -1,5 +1,5 @@
 // use an integer for version numbers
-version = 2
+version = 3
 
 cloudstream {
     // All of these properties are optional, you can safely remove them

--- a/InvidiousProvider/src/main/kotlin/recloudstream/InvidiousProvider.kt
+++ b/InvidiousProvider/src/main/kotlin/recloudstream/InvidiousProvider.kt
@@ -8,7 +8,7 @@ import com.lagradost.cloudstream3.utils.loadExtractor
 import java.net.URLEncoder
 
 class InvidiousProvider : MainAPI() { // all providers must be an instance of MainAPI
-    override var mainUrl = "https://y.com.sb"
+    override var mainUrl = "https://vid.puffyan.us"
     override var name = "Invidious" // name of provider
     override val supportedTypes = setOf(TvType.Others)
 


### PR DESCRIPTION
y.com.sb doesn't seem to work anymore. It was removed from invidious.io about 5 months ago also according to GH commit history for it.