### PR TITLE
Update Invidious URL

### DIFF
--- a/InvidiousProvider/build.gradle.kts
+++ b/InvidiousProvider/build.gradle.kts
@@ -1,5 +1,5 @@
 // use an integer for version numbers
-version = 3
+version = 4
 
 cloudstream {
     // All of these properties are optional, you can safely remove them

--- a/InvidiousProvider/src/main/kotlin/recloudstream/InvidiousProvider.kt
+++ b/InvidiousProvider/src/main/kotlin/recloudstream/InvidiousProvider.kt
@@ -8,7 +8,7 @@ import com.lagradost.cloudstream3.utils.loadExtractor
 import java.net.URLEncoder
 
 class InvidiousProvider : MainAPI() { // all providers must be an instance of MainAPI
-    override var mainUrl = "https://vid.puffyan.us"
+    override var mainUrl = "https://invidious.privacyredirect.com"
     override var name = "Invidious" // name of provider
     override val supportedTypes = setOf(TvType.Others)
 


### PR DESCRIPTION
vid.puffyan.us doesn't seem to work anymore as it seems to require login now which makes CloudStream return "Error loading, try again later." I used invidious.privacyredirect.com via a "Clone site" and this seemed to work.